### PR TITLE
Update map.jinja to use current best practice format

### DIFF
--- a/cobbler/map.jinja
+++ b/cobbler/map.jinja
@@ -1,18 +1,4 @@
-{% set map = {
-    'Ubuntu': {
-        'pkgs': ['dnsmasq',
-                 'syslinux',
-                 'fence-agents',
-                 'xinetd',
-                 'genisoimage',
-                 'yum-utils',
-                 'qemu',
-                 'virtinst',
-                 'tftpd',
-                 'tftp',
-                 'python-augeas',
-                 'libpython2.7']
-    },
+{% set cobbler = salt['grains.filter_by']({
     'Debian': {
         'pkgs': ['dnsmasq',
                  'syslinux',
@@ -27,10 +13,4 @@
                  'python-augeas',
                  'libpython2.7']
     }
-} %}
-
-{% if grains.get('saltversion', '').startswith('0.17') %}
-{% set cobbler = salt['grains.filter_by'](map, merge=salt['pillar.get']('cobbler:lookup'), base='default') %}
-{% else %}
-{% set cobbler = map.get(grains.os) %}
-{% endif %}
+}, merge=salt['pillar.get']('cobbler:lookup')) %}


### PR DESCRIPTION
The map.jinja file was only using grains.filter_by when running on
0.17 salt and otherwise a direct access to grains.os.

Modify to drop grains.os and instead always use filter_by.
Modify to not filter on os but use the default of os_family, which
makes the duplicate Debian/Ubuntu definitions unneeded.